### PR TITLE
feat: added support for visibility condition for Categories, Groups and Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 **Implemented enhancements:**
 
-- Added support setting an optional visibility condition for Categories, Groups and Settings
+- Added support setting an optional visibility condition for Categories, Groups and Settings 
 
 ## [11.7.0](https://github.com/dlsc-software-consulting-gmbh/PreferencesFX/tree/11.7.0) (2020-12-15)
 [Full Changelog](https://github.com/dlsc-software-consulting-gmbh/PreferencesFX/compare/11.6.0...11.7.0)

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ It is possible to optionally add a [Validator](http://dlsc.com/wp-content/html/f
 ## Visibility
 
 PreferencesFX support setting an optional visibility condition for Categories, Groups and Settings
+
 * condition could be defined as a lambda-expression
 * condition will be re-evaluated whenever any Setting changes
 


### PR DESCRIPTION
This PR added support setting an optional visibility condition for Categories, Groups and Settings
* condition could be defined as a lambda-expression
* condition could be re-evaluated whenever any Setting changes
* the views (treeview and settingsview) automatically updated when a visibility changes to show/ hide the Categories, Groups and Settings for which visibility has been changed

<img width="1001" alt="Screenshot 2022-08-02 at 15 48 46" src="https://user-images.githubusercontent.com/7049329/182379376-83778264-bfe2-4c37-98f7-81e25215ea1e.png">

## PR Checklist

- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open an issue first and wait for approval before working on it.
- [x] The code follows the [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html).
- [x] JavaDoc is added / changed for public methods.
- [x] An example of the new feature is added to the [demos](https://github.com/dlemmermann/PreferencesFX/tree/develop/preferencesfx-demo/src/main/java/com/dlsc/preferencesfx).
- [x] Documentation of the feature is included in the [README](https://github.com/dlemmermann/PreferencesFX/blob/develop/README.md).
- [x] Tests for the changes are included.

## What is the current behavior?
Right now PreferencesFX don't have ability to change visibility of Setting, Group, Category

## What is the new behavior?
This PR added show/hide Setting, Group, Category by conditions

Fixes/Resolves/Closes #[Issue Number]

## Breaking Change:
None